### PR TITLE
fix: cannot resolve `@pnpm/logger`

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "@pnpm/constants": "^1001.1.0",
     "@pnpm/find-workspace-dir": "^1000.0.2",
+    "@pnpm/logger": "^1000.0.0",
     "@pnpm/workspace.find-packages": "^1000.0.6",
     "@pnpm/workspace.read-manifest": "^1000.0.2",
     "picocolors": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@pnpm/find-workspace-dir':
         specifier: ^1000.0.2
         version: 1000.0.2
+      '@pnpm/logger':
+        specifier: ^1000.0.0
+        version: 1000.0.0
       '@pnpm/workspace.find-packages':
         specifier: ^1000.0.6
         version: 1000.0.6(@pnpm/logger@1000.0.0)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/pnpmc/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

as follows, `@pnpm/workspace.find-packages` has `@pnpm/logger` as `peerDependencies`, so it should be installed.


```json
  "dependencies": {
    "@pnpm/util.lex-comparator": "3.0.0",
    "@pnpm/cli-utils": "1000.0.6",
    "@pnpm/constants": "1001.1.0",
    "@pnpm/fs.find-packages": "1000.0.4",
    "@pnpm/types": "1000.1.1"
  },
  "funding": "https://opencollective.com/pnpm",
  "devDependencies": {
    "@pnpm/logger": "1000.0.0",
    "@pnpm/workspace.find-packages": "1000.0.6",
    "@pnpm/workspace.read-manifest": "1000.0.2"
  },
  "peerDependencies": {
    "@pnpm/logger": ">=5.1.0 <1001.0.0"
  },
```
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

ref #7 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
