### PR TITLE
feat: support on-demand sub command loading

### DIFF
--- a/packages/pnpmc-utils/src/index.ts
+++ b/packages/pnpmc-utils/src/index.ts
@@ -37,7 +37,9 @@ export async function runCli<A extends Args = Args>(
     version: options.pkgJson.version,
     subCommands: options.subCommands,
     cwd: options.cwd,
-    renderHeader: async ctx => pc.cyanBright(await renderHeaderBase(ctx)),
+    renderHeader: !!process.env.PMPMC_LOADED
+      ? null
+      : async ctx => pc.cyanBright(await renderHeaderBase(ctx)),
     renderValidationErrors: async (ctx, e) => {
       const messages: string[] = []
       messages.push(pc.redBright(await renderValidationErrorsBase(ctx, e)))

--- a/packages/pnpmc/package.json
+++ b/packages/pnpmc/package.json
@@ -38,7 +38,9 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "gunshi": "catalog:"
+    "gunshi": "catalog:",
+    "package-manager-detector": "^1.3.0",
+    "tinyexec": "^1.0.1"
   },
   "peerDependencies": {
     "pnpmc-register": "workspace:*",

--- a/packages/pnpmc/src/commands.ts
+++ b/packages/pnpmc/src/commands.ts
@@ -6,11 +6,9 @@
 import { lazy } from 'gunshi/definition'
 import { default as metaRegister } from 'pnpmc-register/meta'
 import { default as metaShow } from 'pnpmc-show/meta'
+import { load } from './loader.js'
 
-export const showLazy = lazy<typeof metaShow.args>(
-  async () => (await import('pnpmc-show/runner')).default,
-  metaShow
-)
+export const showLazy = lazy<typeof metaShow.args>(async () => await load('pnpmc-show'), metaShow)
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const commands: Map<string, any> = new Map()
@@ -18,8 +16,5 @@ export const commands: Map<string, any> = new Map()
 commands.set(metaShow.name, showLazy)
 commands.set(
   metaRegister.name,
-  lazy<typeof metaRegister.args>(
-    async () => (await import('pnpmc-register/runner')).default,
-    metaRegister
-  )
+  lazy<typeof metaRegister.args>(async () => await load('pnpmc-register'), metaRegister)
 )

--- a/packages/pnpmc/src/loader.ts
+++ b/packages/pnpmc/src/loader.ts
@@ -1,0 +1,65 @@
+/**
+ * @author kazuya kawaguchi (a.k.a @kazupon)
+ * @license MIT
+ */
+
+import { detect, resolveCommand } from 'package-manager-detector'
+import { x } from 'tinyexec'
+
+import type { Args, CommandContext, CommandRunner } from 'gunshi'
+
+export async function load<A extends Args = Args>(pkg: string): Promise<CommandRunner<A>> {
+  const mod = await loadCommandRunner<A>(`${pkg}/runner`)
+  if (mod != null) {
+    return mod
+  } else {
+    const pm = await detect()
+    if (pm == null) {
+      throw new Error('Fatal Error: Cannot detect package manager')
+    }
+    async function runner<A extends Args>(ctx: CommandContext<A>): Promise<void> {
+      const subCommand = ctx.env.version ? `${pkg}@${ctx.env.version}` : pkg
+      const resolvedCommand = resolveCommand(pm!.agent, 'execute', [subCommand, ...ctx._.slice(1)]) // resolved args with removed the sub-command of parent command
+      if (resolvedCommand == null) {
+        throw new Error(`Fatal Error: Cannot resolve command '${ctx._[0]}'`)
+      }
+      await x(resolvedCommand.command, resolvedCommand.args, {
+        nodeOptions: {
+          cwd: ctx.env.cwd,
+          stdio: 'inherit',
+          env: {
+            ...process.env,
+            PMPMC_LOADED: 'true'
+          }
+        }
+      })
+    }
+    return runner
+  }
+}
+
+async function loadCommandRunner<A extends Args = Args>(
+  pkg: string
+): Promise<CommandRunner<A> | null> {
+  let mod: Promise<CommandRunner<A> | null> | undefined
+  try {
+    mod = await import(pkg).then(m => m.default || m)
+  } catch (e: unknown) {
+    if (isErrorModuleNotFound(e)) {
+      mod = Promise.resolve(null)
+    }
+  }
+  if (mod === undefined) {
+    throw new Error(`Fatal Error: '${pkg}' Commnad Runner loading failed`)
+  }
+  return mod
+}
+
+function isErrorModuleNotFound(e: unknown): e is NodeJS.ErrnoException {
+  return (
+    e instanceof Error &&
+    'code' in e &&
+    typeof e.code === 'string' &&
+    e.code === 'ERR_MODULE_NOT_FOUND'
+  )
+}

--- a/packages/pnpmc/src/loader.ts
+++ b/packages/pnpmc/src/loader.ts
@@ -50,7 +50,7 @@ async function loadCommandRunner<A extends Args = Args>(
     }
   }
   if (mod === undefined) {
-    throw new Error(`Fatal Error: '${pkg}' Commnad Runner loading failed`)
+    throw new Error(`Fatal Error: '${pkg}' Command Runner loading failed`)
   }
   return mod
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,12 +80,18 @@ importers:
       gunshi:
         specifier: 'catalog:'
         version: 0.23.1
+      package-manager-detector:
+        specifier: ^1.3.0
+        version: 1.3.0
       pnpmc-register:
         specifier: workspace:*
         version: link:../pnpmc-register
       pnpmc-show:
         specifier: workspace:*
         version: link:../pnpmc-show
+      tinyexec:
+        specifier: ^1.0.1
+        version: 1.0.1
     devDependencies:
       pnpmc-utils:
         specifier: workspace:*
@@ -2441,8 +2447,8 @@ packages:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
 
-  package-manager-detector@1.0.0:
-    resolution: {integrity: sha512-7elnH+9zMsRo7aS72w6MeRugTpdRvInmEB4Kmm9BVvPw/SLG8gXUGQ+4wF0Mys0RSWPz0B9nuBbDe8vFeA2sfg==}
+  package-manager-detector@1.3.0:
+    resolution: {integrity: sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -4144,7 +4150,7 @@ snapshots:
       cac: 6.7.14
       escalade: 3.2.0
       jsonc-parser: 3.3.1
-      package-manager-detector: 1.0.0
+      package-manager-detector: 1.3.0
       semver: 7.7.1
       tinyexec: 0.3.2
       tinyglobby: 0.2.12
@@ -5411,7 +5417,7 @@ snapshots:
 
   p-map@2.1.0: {}
 
-  package-manager-detector@1.0.0: {}
+  package-manager-detector@1.3.0: {}
 
   parent-module@1.0.1:
     dependencies:


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/pnpmc/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for dynamically loading command runners with a fallback to execute commands using the detected package manager if the runner module is not found.
- **Chores**
	- Updated dependencies by adding "package-manager-detector" and "tinyexec".
- **Refactor**
	- Centralized and streamlined the loading of command runners for improved reliability and maintainability.
- **Style**
	- Header rendering is now conditionally disabled based on an environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->